### PR TITLE
adding MAX31856 support

### DIFF
--- a/PIDKiln.h
+++ b/PIDKiln.h
@@ -38,8 +38,8 @@ const int MAX_Prog_File_Size=10240;  // maximum file size (bytes) that can be up
 
 // if you use MAX31856 (supports differnent thermocouple types)
 // uncomment accordingly
-#define TC_TYPE_KILN MAX31856_TCTYPE_J
-#define TC_TYPE_HOUSING MAX31856_TCTYPE_J
+// #define TC_TYPE_KILN MAX31856_TCTYPE_J
+// #define TC_TYPE_HOUSING MAX31856_TCTYPE_J
 
 // If you have power meter - uncoment this
 //#define ENERGY_MON_PIN 33       // if you don't use - comment out

--- a/PIDKiln.h
+++ b/PIDKiln.h
@@ -23,13 +23,23 @@ const int MAX_Prog_File_Size=10240;  // maximum file size (bytes) that can be up
 //#define SSR2_RELAY_PIN 22   // if you want to use additional SSR for second heater, uncoment this
 
 // Thermocouple variables/defs
-#define MAXCS1  27    // for hardware SPI - HSPI (MOSI-13, MISO-12, CLK-14) - 1st device CS-27
-#define MAXCS2  15    // same SPI - 2nd device CS-15 (comment out if no second thermocouple)
+// available TC board types
+#define TC_BOARD_MAX31855 1
+#define TC_BOARD_MAX31856 2
 
-// if you want to use MAX31856 (supports differnent thermocouple types)
+// put any of the above or do not define depending on your hardware
+#define TC_BOARD_TYPE_KILN TC_BOARD_MAX31855
+#define TC_BOARD_TYPE_HOUSING TC_BOARD_MAX31855
+
+// for hardware SPI - HSPI (MOSI-13, MISO-12, CLK-14) - 1st device CS-27
+#define TC_CS_KILN 27
+// same SPI - 2nd device CS-15 (comment out if no second thermocouple)
+#define TC_CS_HOUSING 15
+
+// if you use MAX31856 (supports differnent thermocouple types)
 // uncomment accordingly
-// #define MAXTYPE1 MAX31856_TCTYPE_J
-// #define MAXTYPE2 MAX31856_TCTYPE_J
+#define TC_TYPE_KILN MAX31856_TCTYPE_J
+#define TC_TYPE_HOUSING MAX31856_TCTYPE_J
 
 // If you have power meter - uncoment this
 //#define ENERGY_MON_PIN 33       // if you don't use - comment out
@@ -135,7 +145,10 @@ time_t Program_run_end=0;         // date/time when program ends - during progra
 int Program_run_step=-1;          // at which step are we now... (has to be it - so we can give it -1)
 uint16_t Program_start_temp=0;    // temperature on start of the program
 uint8_t Program_error=0;          // if program finished with errors - remember number
-byte TempA_errors=0,TempB_errors=0; // how many temperature read errors we have skipped
+
+// how many temperature read errors we have skipped
+byte Temp_Kiln_errors = 0;
+byte Temp_Housing_errors = 0;
 
 typedef enum { // program menu positions
   PR_NONE,

--- a/PIDKiln.h
+++ b/PIDKiln.h
@@ -22,9 +22,14 @@ const int MAX_Prog_File_Size=10240;  // maximum file size (bytes) that can be up
 #define SSR1_RELAY_PIN 19
 //#define SSR2_RELAY_PIN 22   // if you want to use additional SSR for second heater, uncoment this
 
-// MAX31855 variables/defs
+// Thermocouple variables/defs
 #define MAXCS1  27    // for hardware SPI - HSPI (MOSI-13, MISO-12, CLK-14) - 1st device CS-27
 #define MAXCS2  15    // same SPI - 2nd device CS-15 (comment out if no second thermocouple)
+
+// if you want to use MAX31856 (supports differnent thermocouple types)
+// uncomment accordingly
+// #define MAXTYPE1 MAX31856_TCTYPE_J
+// #define MAXTYPE2 MAX31856_TCTYPE_J
 
 // If you have power meter - uncoment this
 //#define ENERGY_MON_PIN 33       // if you don't use - comment out
@@ -36,7 +41,7 @@ uint16_t ALARM_countdown=0; // countdown in seconds to stop alarm
 ** Temperature, PID and probes variables/definitions
 */
 // Temperature & PID variables
-double int_temp=20, kiln_temp=20, case_temp=20;
+double int_temp = 20, kiln_temp = 20, case_temp = 20;
 double set_temp, pid_out;
 float temp_incr=0;
 uint32_t windowStartTime;

--- a/PIDKiln_MAX31855.ino
+++ b/PIDKiln_MAX31855.ino
@@ -1,0 +1,67 @@
+#if (TC_BOARD_TYPE_KILN == TC_BOARD_MAX31855) || (TC_BOARD_TYPE_HOUSING == TC_BOARD_MAX31855)
+#include <MAX31855.h>
+extern SPIClass ESP32_SPI;
+
+// MAX31855 temperature readout
+template <class TC>
+void Read_Temperature_MAX31855(TC &Thermocouple, double &tc_reading,
+                               double &cj_reading, uint8_t &fault) {
+  uint32_t raw = Thermocouple.readRawData();
+
+  if (!raw) { // probably MAX31855 not connected
+    DBG dbgLog(LOG_ERR, "[MAX31855] Board did not respond\n");
+    fault = MAX31855_ERROR;
+    return;
+  }
+
+  if (Thermocouple.detectThermocouple(raw) != MAX31855_THERMOCOUPLE_OK) {
+    fault = Thermocouple.detectThermocouple();
+    switch (fault) {
+    case MAX31855_THERMOCOUPLE_SHORT_TO_VCC:
+      DBG dbgLog(LOG_ERR, "[MAX31855] short to VCC\n");
+      break;
+
+    case MAX31855_THERMOCOUPLE_SHORT_TO_GND:
+      DBG dbgLog(LOG_ERR, "[MAX31855] short to GND\n");
+      break;
+
+    case MAX31855_THERMOCOUPLE_NOT_CONNECTED:
+      DBG dbgLog(LOG_ERR, "[MAX31855] not connected\n");
+      break;
+
+    default:
+      DBG dbgLog(LOG_ERR, "[MAX31855] unknown error, check spi cable\n");
+      break;
+    }
+    return;
+  }
+
+  cj_reading = Thermocouple.getColdJunctionTemperature(raw);
+  tc_reading = Thermocouple.getTemperature(raw);
+}
+#endif
+
+#if TC_BOARD_TYPE_KILN == TC_BOARD_MAX31855
+// Initialize MAX31855 of KILN
+MAX31855 Thermocouple_Kiln(TC_CS_KILN);
+// Thermocouple_Kiln temperature readout
+void Read_Temperature_Kiln(double &tc_reading, double &cj_reading,
+                           uint8_t &fault) {
+  Read_Temperature_MAX31855(Thermocouple_Kiln, tc_reading, cj_reading, fault);
+}
+
+void Setup_Thermocouple_Kiln() { Thermocouple_Kiln.begin(&ESP32_SPI); }
+#endif
+
+#if TC_BOARD_TYPE_HOUSING == TC_BOARD_MAX31855
+// Initialize MAX31855 of HOSING
+MAX31855 Thermocouple_Housing(TC_CS_HOUSING);
+// Thermocouple_Housing temperature readout
+void Read_Temperature_Housing(double &tc_reading, double &cj_reading,
+                              uint8_t &fault) {
+  Read_Temperature_MAX31855(Thermocouple_Housing, tc_reading, cj_reading,
+                            fault);
+}
+
+void Setup_Thermocouple_Housing() { Thermocouple_Housing.begin(&ESP32_SPI); }
+#endif

--- a/PIDKiln_MAX31856.ino
+++ b/PIDKiln_MAX31856.ino
@@ -1,0 +1,52 @@
+#if (TC_BOARD_TYPE_KILN == TC_BOARD_MAX31856) || (TC_BOARD_TYPE_HOUSING == TC_BOARD_MAX31856)
+#include <Adafruit_MAX31856.h>
+extern SPIClass ESP32_SPI;
+
+// MAX31855 temperature readout
+template <class TC>
+void Read_Temperature_MAX31856(TC& Thermocouple, double& tc_reading, double& cj_reading, uint8_t& fault){
+  fault = Thermocouple.readFault();
+  if (fault) {
+    if (fault & MAX31856_FAULT_CJRANGE){ DBG dbgLog(LOG_ERR,"[MAX31856] Cold Junction Range Fault");}
+    if (fault & MAX31856_FAULT_TCRANGE){ DBG dbgLog(LOG_ERR,"[MAX31856] Thermocouple Range Fault");}
+    if (fault & MAX31856_FAULT_CJHIGH){  DBG dbgLog(LOG_ERR,"[MAX31856] Cold Junction High Fault");}
+    if (fault & MAX31856_FAULT_CJLOW){   DBG dbgLog(LOG_ERR,"[MAX31856] Cold Junction Low Fault");}
+    if (fault & MAX31856_FAULT_TCHIGH){  DBG dbgLog(LOG_ERR,"[MAX31856] Thermocouple High Fault");}
+    if (fault & MAX31856_FAULT_TCLOW){   DBG dbgLog(LOG_ERR,"[MAX31856] Thermocouple Low Fault");}
+    if (fault & MAX31856_FAULT_OVUV){    DBG dbgLog(LOG_ERR,"[MAX31856] Over/Under Voltage Fault");}
+    if (fault & MAX31856_FAULT_OPEN){    DBG dbgLog(LOG_ERR,"[MAX31856] Thermocouple Open Fault");}
+    return;
+  }
+
+  cj_reading = Thermocouple.readCJTemperature(); 
+  tc_reading = Thermocouple.readThermocoupleTemperature();
+}
+#endif
+
+
+
+#if TC_BOARD_TYPE_KILN == TC_BOARD_MAX31856
+// Initialize MAX31856 of KILN
+Adafruit_MAX31856 Thermocouple_Kiln(TC_CS_KILN,&ESP32_SPI);
+// Thermocouple_Kiln temperature readout
+void Read_Temperature_Kiln(double& tc_reading, double& cj_reading, uint8_t& fault){
+  Read_Temperature_MAX31856(Thermocouple_Kiln,tc_reading,cj_reading,fault);
+}
+
+void Setup_Thermocouple_Kiln(){
+  Thermocouple_Kiln.begin();
+}
+#endif
+
+#if TC_BOARD_TYPE_HOUSING == TC_BOARD_MAX31856
+// Initialize MAX31856 of HOSING
+Adafruit_MAX31856 Thermocouple_Housing(TC_CS_HOUSING,&ESP32_SPI);
+// Thermocouple_Housing temperature readout
+void Read_Temperature_Housing(double& tc_reading, double& cj_reading, uint8_t& fault){
+  Read_Temperature_MAX31856(Thermocouple_Housing,tc_reading,cj_reading,fault);
+}
+
+void Setup_Thermocouple_Housing(){
+  Thermocouple_Housing.begin();
+}
+#endif

--- a/PIDKiln_addons.ino
+++ b/PIDKiln_addons.ino
@@ -8,12 +8,13 @@
 #include <MAX31855.h>
 #endif
 
+#ifdef MAXCS2
 #ifdef MAXTYPE2
 #include <Adafruit_MAX31856.h>
 #else
 #include <MAX31855.h>
 #endif
-
+#endif
 
 // Initialize SPI and MAX31855
 SPIClass *ESP32_SPI = new SPIClass(HSPI);

--- a/PIDKiln_addons.ino
+++ b/PIDKiln_addons.ino
@@ -2,11 +2,26 @@
 ** Function for relays (SSR, EMR) and temperature sensors
 **
 */
+#ifdef MAXTYPE1
+#include <Adafruit_MAX31856.h>
+#else
 #include <MAX31855.h>
+#endif
+
+#ifdef MAXTYPE2
+#include <Adafruit_MAX31856.h>
+#else
+#include <MAX31855.h>
+#endif
+
 
 // Initialize SPI and MAX31855
 SPIClass *ESP32_SPI = new SPIClass(HSPI);
+#ifdef MAXTYPE1
+Adafruit_MAX31856 ThermocoupleA(MAXCS1,ESP32_SPI);
+#else
 MAX31855 ThermocoupleA(MAXCS1);
+#endif
 
 // If we have defines power meter pins
 #ifdef ENERGY_MON_PIN
@@ -21,7 +36,11 @@ double Energy_Usage=0;            // total energy used (Watt/time)
 
 // If you have second thermoucouple
 #ifdef MAXCS2
+#ifdef MAXTYPE2
+Adafruit_MAX31856 ThermocoupleB(MAXCS2,ESP32_SPI);
+#else
 MAX31855 ThermocoupleB(MAXCS2);
+#endif
 #endif
 
 boolean SSR_On; // just to narrow down state changes.. I don't know if this is needed/faster
@@ -70,12 +89,39 @@ Serial.println();
 // ThermocoupleA temperature readout
 //
 void Update_TemperatureA(){
-uint32_t raw;
-double kiln_tmp1;
+#ifdef MAXTYPE1
+  double kiln_tmp1;
+  uint8_t fault = ThermocoupleA.readFault();
+  if (fault) {
+    if (fault & MAX31856_FAULT_CJRANGE){ DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA Cold Junction Range Fault");}
+    if (fault & MAX31856_FAULT_TCRANGE){ DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA Thermocouple Range Fault");}
+    if (fault & MAX31856_FAULT_CJHIGH){  DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA Cold Junction High Fault");}
+    if (fault & MAX31856_FAULT_CJLOW){   DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA Cold Junction Low Fault");}
+    if (fault & MAX31856_FAULT_TCHIGH){  DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA Thermocouple High Fault");}
+    if (fault & MAX31856_FAULT_TCLOW){   DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA Thermocouple Low Fault");}
+    if (fault & MAX31856_FAULT_OVUV){    DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA Over/Under Voltage Fault");}
+    if (fault & MAX31856_FAULT_OPEN){    DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA Thermocouple Open Fault");}
+
+    if(TempA_errors<Prefs[PRF_ERROR_GRACE_COUNT].value.uint8){
+      TempA_errors++;
+      DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA had an error but we are still below grace threshold - continue. Error %d of %d\n",TempA_errors,Prefs[PRF_ERROR_GRACE_COUNT].value.uint8);
+    }else{
+      ABORT_Program(PR_ERR_MAX31A_INT_ERR);
+    }
+    return;
+  }
+
+  kiln_tmp1 = ThermocoupleA.readCJTemperature(); 
+  int_temp = (int_temp+kiln_tmp1)/2;
+  
+  kiln_tmp1 = ThermocoupleA.readThermocoupleTemperature();
+  kiln_temp=(kiln_temp*0.9+kiln_tmp1*0.1);    // We try to make bigger hysteresis
+
+#else
+  uint32_t raw;
+  double kiln_tmp1;
 
   raw = ThermocoupleA.readRawData();
-//Serial.print("A");
-//print_bits(raw);
 
   if(!raw){ // probably MAX31855 not connected
     DBG dbgLog(LOG_ERR,"[ADDONS] MAX31855 for ThermocoupleA did not respond\n");
@@ -116,6 +162,8 @@ double kiln_tmp1;
   kiln_tmp1 = ThermocoupleA.getTemperature(raw);
   kiln_temp=(kiln_temp*0.9+kiln_tmp1*0.1);    // We try to make bigger hysteresis
 
+#endif
+
   if(TempA_errors>0) TempA_errors--;  // Lower errors count after proper readout
   
   DBG dbgLog(LOG_DEBUG, "[ADDONS] Temperature sensor A readout: Internal temp = %.1f \t Last temp = %.1f \t Average kiln temp = %.1f\n", int_temp, kiln_tmp1, kiln_temp); 
@@ -126,12 +174,40 @@ double kiln_tmp1;
 // ThermocoupleB temperature readout
 //
 void Update_TemperatureB(){
-uint32_t raw;
-double case_tmp1;
+#ifdef MAXTYPE2
+  double case_tmp1;
+  uint8_t fault = ThermocoupleB.readFault();
+  if (fault) {
+    if (fault & MAX31856_FAULT_CJRANGE){ DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB Cold Junction Range Fault");}
+    if (fault & MAX31856_FAULT_TCRANGE){ DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB Thermocouple Range Fault");}
+    if (fault & MAX31856_FAULT_CJHIGH){  DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB Cold Junction High Fault");}
+    if (fault & MAX31856_FAULT_CJLOW){   DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB Cold Junction Low Fault");}
+    if (fault & MAX31856_FAULT_TCHIGH){  DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB Thermocouple High Fault");}
+    if (fault & MAX31856_FAULT_TCLOW){   DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB Thermocouple Low Fault");}
+    if (fault & MAX31856_FAULT_OVUV){    DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB Over/Under Voltage Fault");}
+    if (fault & MAX31856_FAULT_OPEN){    DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB Thermocouple Open Fault");}
+
+    if(TempB_errors<Prefs[PRF_ERROR_GRACE_COUNT].value.uint8){
+      TempB_errors++;
+      DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB had an error but we are still below grace threshold - continue. Error %d of %d\n",TempA_errors,Prefs[PRF_ERROR_GRACE_COUNT].value.uint8);
+    }else{
+      ABORT_Program(PR_ERR_MAX31B_INT_ERR);
+    }
+    return;
+  }
+
+  case_tmp1 = ThermocoupleB.readCJTemperature(); 
+  int_temp = (int_temp+case_tmp1)/2;
+  
+  case_tmp1 = ThermocoupleB.readThermocoupleTemperature();
+  case_temp=(case_temp*0.8+case_tmp1*0.2);    // We try to make bigger hysteresis
+
+#else
+  uint32_t raw;
+  double case_tmp1;
 
   raw = ThermocoupleB.readRawData();
-//Serial.print("B");
-//print_bits(raw);
+  
   if(!raw){ // probably MAX31855 not connected
     DBG dbgLog(LOG_ERR,"[ADDONS] MAX31855 for ThermocoupleB did not respond\n");
     ABORT_Program(PR_ERR_MAX31B_NC);
@@ -170,6 +246,8 @@ double case_tmp1;
   
   case_tmp1 = ThermocoupleB.getTemperature(raw);
   case_temp=(case_temp*0.8+case_tmp1*0.2);    // We try to make bigger hysteresis
+
+#endif
   
   if(TempB_errors>0) TempB_errors--;  // Lower errors count after proper readout
 
@@ -246,9 +324,20 @@ void Setup_Addons(){
   pinMode(ALARM_PIN, OUTPUT);
 
   SSR_On=false;
+#ifdef MAXTYPE1
+  ThermocoupleA.begin();
+  ThermocoupleA.setThermocoupleType(MAXTYPE1);
+#else
   ThermocoupleA.begin(ESP32_SPI);
+#endif
 #ifdef MAXCS2
+#ifdef MAXTYPE2
+  ThermocoupleB.begin();
+  ThermocoupleB.setThermocoupleType(MAXTYPE2);
+#else
   ThermocoupleB.begin(ESP32_SPI);
+#endif
+
 #endif
 #ifdef ENERGY_MON_PIN
   emon1.current(ENERGY_MON_PIN, ENERGY_MON_AMPS);

--- a/PIDKiln_addons.ino
+++ b/PIDKiln_addons.ino
@@ -2,27 +2,10 @@
 ** Function for relays (SSR, EMR) and temperature sensors
 **
 */
-#ifdef MAXTYPE1
-#include <Adafruit_MAX31856.h>
-#else
-#include <MAX31855.h>
-#endif
 
-#ifdef MAXCS2
-#ifdef MAXTYPE2
-#include <Adafruit_MAX31856.h>
-#else
-#include <MAX31855.h>
-#endif
-#endif
-
-// Initialize SPI and MAX31855
-SPIClass *ESP32_SPI = new SPIClass(HSPI);
-#ifdef MAXTYPE1
-Adafruit_MAX31856 ThermocoupleA(MAXCS1,ESP32_SPI);
-#else
-MAX31855 ThermocoupleA(MAXCS1);
-#endif
+// SPIClass for thermocouples
+// SPIClass *ESP32_SPI = new SPIClass(HSPI);
+SPIClass ESP32_SPI(HSPI);    // object, not pointer
 
 // If we have defines power meter pins
 #ifdef ENERGY_MON_PIN
@@ -35,14 +18,6 @@ EnergyMonitor emon1;
 uint16_t Energy_Wattage=0;        // keeping present power consumtion in Watts
 double Energy_Usage=0;            // total energy used (Watt/time)
 
-// If you have second thermoucouple
-#ifdef MAXCS2
-#ifdef MAXTYPE2
-Adafruit_MAX31856 ThermocoupleB(MAXCS2,ESP32_SPI);
-#else
-MAX31855 ThermocoupleB(MAXCS2);
-#endif
-#endif
 
 boolean SSR_On; // just to narrow down state changes.. I don't know if this is needed/faster
 
@@ -86,176 +61,53 @@ void print_bits(uint32_t raw){
 Serial.println();
 }
 
-
-// ThermocoupleA temperature readout
-//
-void Update_TemperatureA(){
-#ifdef MAXTYPE1
-  double kiln_tmp1;
-  uint8_t fault = ThermocoupleA.readFault();
-  if (fault) {
-    if (fault & MAX31856_FAULT_CJRANGE){ DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA Cold Junction Range Fault");}
-    if (fault & MAX31856_FAULT_TCRANGE){ DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA Thermocouple Range Fault");}
-    if (fault & MAX31856_FAULT_CJHIGH){  DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA Cold Junction High Fault");}
-    if (fault & MAX31856_FAULT_CJLOW){   DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA Cold Junction Low Fault");}
-    if (fault & MAX31856_FAULT_TCHIGH){  DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA Thermocouple High Fault");}
-    if (fault & MAX31856_FAULT_TCLOW){   DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA Thermocouple Low Fault");}
-    if (fault & MAX31856_FAULT_OVUV){    DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA Over/Under Voltage Fault");}
-    if (fault & MAX31856_FAULT_OPEN){    DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA Thermocouple Open Fault");}
-
-    if(TempA_errors<Prefs[PRF_ERROR_GRACE_COUNT].value.uint8){
-      TempA_errors++;
-      DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA had an error but we are still below grace threshold - continue. Error %d of %d\n",TempA_errors,Prefs[PRF_ERROR_GRACE_COUNT].value.uint8);
+// Kiln Thermocouple temperature update
+void Update_Temperature_Kiln(){
+  uint8_t fault=0;
+  double tc_temp, cj_temp;
+  Read_Temperature_Kiln(tc_temp,cj_temp,fault);
+  if (fault!=0){
+    if(Temp_Kiln_errors<Prefs[PRF_ERROR_GRACE_COUNT].value.uint8){
+      Temp_Kiln_errors++;
+      DBG dbgLog(LOG_ERR,"[ADDONS] Kiln Thermocouple had an error but we are still below grace threshold - continue. Error %d of %d\n",Temp_Kiln_errors,Prefs[PRF_ERROR_GRACE_COUNT].value.uint8);
     }else{
       ABORT_Program(PR_ERR_MAX31A_INT_ERR);
     }
     return;
   }
 
-  kiln_tmp1 = ThermocoupleA.readCJTemperature(); 
-  int_temp = (int_temp+kiln_tmp1)/2;
+  int_temp = (int_temp+cj_temp)/2;
+  kiln_temp=(kiln_temp*0.9+tc_temp*0.1);    // We try to make bigger hysteresis
+
+  if(Temp_Kiln_errors>0) Temp_Kiln_errors--;  // Lower errors count after proper readout
   
-  kiln_tmp1 = ThermocoupleA.readThermocoupleTemperature();
-  kiln_temp=(kiln_temp*0.9+kiln_tmp1*0.1);    // We try to make bigger hysteresis
-
-#else
-  uint32_t raw;
-  double kiln_tmp1;
-
-  raw = ThermocoupleA.readRawData();
-
-  if(!raw){ // probably MAX31855 not connected
-    DBG dbgLog(LOG_ERR,"[ADDONS] MAX31855 for ThermocoupleA did not respond\n");
-    ABORT_Program(PR_ERR_MAX31A_NC);
-    return;
-  }
-  if(ThermocoupleA.detectThermocouple(raw) != MAX31855_THERMOCOUPLE_OK){
-    switch (ThermocoupleA.detectThermocouple())
-    {
-      case MAX31855_THERMOCOUPLE_SHORT_TO_VCC:
-        DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA short to VCC\n");
-        break;
-
-      case MAX31855_THERMOCOUPLE_SHORT_TO_GND:
-        DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA short to GND\n");
-        break;
-
-      case MAX31855_THERMOCOUPLE_NOT_CONNECTED:
-        DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA not connected\n");
-        break;
-
-      default:
-        DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA unknown error, check spi cable\n");
-        break;
-    }
-    if(TempA_errors<Prefs[PRF_ERROR_GRACE_COUNT].value.uint8){
-      TempA_errors++;
-      DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleA had an error but we are still below grace threshold - continue. Error %d of %d\n",TempA_errors,Prefs[PRF_ERROR_GRACE_COUNT].value.uint8);
-    }else{
-      ABORT_Program(PR_ERR_MAX31A_INT_ERR);
-    }
-    return;
-  }
-
-  kiln_tmp1 = ThermocoupleA.getColdJunctionTemperature(raw); 
-  int_temp = (int_temp+kiln_tmp1)/2;
-  
-  kiln_tmp1 = ThermocoupleA.getTemperature(raw);
-  kiln_temp=(kiln_temp*0.9+kiln_tmp1*0.1);    // We try to make bigger hysteresis
-
-#endif
-
-  if(TempA_errors>0) TempA_errors--;  // Lower errors count after proper readout
-  
-  DBG dbgLog(LOG_DEBUG, "[ADDONS] Temperature sensor A readout: Internal temp = %.1f \t Last temp = %.1f \t Average kiln temp = %.1f\n", int_temp, kiln_tmp1, kiln_temp); 
+  DBG dbgLog(LOG_DEBUG, "[ADDONS] Kiln Temperature sensor readout: Internal temp = %.1f \t Last temp = %.1f \t Average kiln temp = %.1f\n", int_temp, tc_temp, kiln_temp); 
 }
 
-
-#ifdef MAXCS2
-// ThermocoupleB temperature readout
-//
-void Update_TemperatureB(){
-#ifdef MAXTYPE2
-  double case_tmp1;
-  uint8_t fault = ThermocoupleB.readFault();
-  if (fault) {
-    if (fault & MAX31856_FAULT_CJRANGE){ DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB Cold Junction Range Fault");}
-    if (fault & MAX31856_FAULT_TCRANGE){ DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB Thermocouple Range Fault");}
-    if (fault & MAX31856_FAULT_CJHIGH){  DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB Cold Junction High Fault");}
-    if (fault & MAX31856_FAULT_CJLOW){   DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB Cold Junction Low Fault");}
-    if (fault & MAX31856_FAULT_TCHIGH){  DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB Thermocouple High Fault");}
-    if (fault & MAX31856_FAULT_TCLOW){   DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB Thermocouple Low Fault");}
-    if (fault & MAX31856_FAULT_OVUV){    DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB Over/Under Voltage Fault");}
-    if (fault & MAX31856_FAULT_OPEN){    DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB Thermocouple Open Fault");}
-
-    if(TempB_errors<Prefs[PRF_ERROR_GRACE_COUNT].value.uint8){
-      TempB_errors++;
-      DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB had an error but we are still below grace threshold - continue. Error %d of %d\n",TempA_errors,Prefs[PRF_ERROR_GRACE_COUNT].value.uint8);
+// Housing Thermocouple temperature update
+#ifdef TC_BOARD_TYPE_HOUSING
+void Update_Temperature_Housing(){
+  uint8_t fault=0;
+  double tc_temp, cj_temp;
+  Read_Temperature_Housing(tc_temp,cj_temp,fault);
+  if (fault!=0){
+    if(Temp_Housing_errors<Prefs[PRF_ERROR_GRACE_COUNT].value.uint8){
+      Temp_Housing_errors++;
+      DBG dbgLog(LOG_ERR,"[ADDONS] Housing Thermocouple had an error but we are still below grace threshold - continue. Error %d of %d\n",Temp_Housing_errors,Prefs[PRF_ERROR_GRACE_COUNT].value.uint8);
     }else{
       ABORT_Program(PR_ERR_MAX31B_INT_ERR);
     }
     return;
   }
 
-  case_tmp1 = ThermocoupleB.readCJTemperature(); 
-  int_temp = (int_temp+case_tmp1)/2;
+  int_temp = (int_temp+cj_temp)/2;
+  case_temp=(case_temp*0.8+tc_temp*0.2);    // We try to make bigger hysteresis
+
+  if(Temp_Housing_errors>0) Temp_Housing_errors--;  // Lower errors count after proper readout
   
-  case_tmp1 = ThermocoupleB.readThermocoupleTemperature();
-  case_temp=(case_temp*0.8+case_tmp1*0.2);    // We try to make bigger hysteresis
-
-#else
-  uint32_t raw;
-  double case_tmp1;
-
-  raw = ThermocoupleB.readRawData();
-  
-  if(!raw){ // probably MAX31855 not connected
-    DBG dbgLog(LOG_ERR,"[ADDONS] MAX31855 for ThermocoupleB did not respond\n");
-    ABORT_Program(PR_ERR_MAX31B_NC);
-    return;
-  }
-  if(ThermocoupleB.detectThermocouple(raw) != MAX31855_THERMOCOUPLE_OK){
-    switch (ThermocoupleB.detectThermocouple())
-    {
-      case MAX31855_THERMOCOUPLE_SHORT_TO_VCC:
-        DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB short to VCC\n");
-        break;
-
-      case MAX31855_THERMOCOUPLE_SHORT_TO_GND:
-        DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB short to GND\n");
-        break;
-
-      case MAX31855_THERMOCOUPLE_NOT_CONNECTED:
-        DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB not connected\n");
-        break;
-
-      default:
-        DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB unknown error, check spi cable\n");
-        break;
-    }
-    if(TempB_errors<Prefs[PRF_ERROR_GRACE_COUNT].value.uint8){
-      TempB_errors++;
-      DBG dbgLog(LOG_ERR,"[ADDONS] ThermocoupleB had an error but we are still below grace threshold - continue. Error %d of %d\n",TempB_errors,Prefs[PRF_ERROR_GRACE_COUNT].value.uint8);
-    }else{
-      ABORT_Program(PR_ERR_MAX31B_INT_ERR);
-    }
-    return;
-  }
-
-  case_tmp1 = ThermocoupleB.getColdJunctionTemperature(raw); 
-  int_temp = (int_temp+case_tmp1)/2;
-  
-  case_tmp1 = ThermocoupleB.getTemperature(raw);
-  case_temp=(case_temp*0.8+case_tmp1*0.2);    // We try to make bigger hysteresis
-
-#endif
-  
-  if(TempB_errors>0) TempB_errors--;  // Lower errors count after proper readout
-
-  DBG dbgLog(LOG_DEBUG,"[ADDONS] Temperature sensor B readout: Internal temp = %.1f \t Last temp = %.1f \t Average case temp = %.1f\n", int_temp, case_tmp1, case_temp); 
+  DBG dbgLog(LOG_DEBUG, "[ADDONS] Housing Temperature sensor readout: Internal temp = %.1f \t Last temp = %.1f \t Average kiln temp = %.1f\n", int_temp, tc_temp, case_temp); 
 }
 #endif
-
 
 // Measure current power usage - to be expanded
 //
@@ -325,21 +177,11 @@ void Setup_Addons(){
   pinMode(ALARM_PIN, OUTPUT);
 
   SSR_On=false;
-#ifdef MAXTYPE1
-  ThermocoupleA.begin();
-  ThermocoupleA.setThermocoupleType(MAXTYPE1);
-#else
-  ThermocoupleA.begin(ESP32_SPI);
-#endif
-#ifdef MAXCS2
-#ifdef MAXTYPE2
-  ThermocoupleB.begin();
-  ThermocoupleB.setThermocoupleType(MAXTYPE2);
-#else
-  ThermocoupleB.begin(ESP32_SPI);
+  Setup_Thermocouple_Kiln();
+#ifdef TC_BOARD_TYPE_HOUSING
+  Setup_Thermocouple_Housing();
 #endif
 
-#endif
 #ifdef ENERGY_MON_PIN
   emon1.current(ENERGY_MON_PIN, ENERGY_MON_AMPS);
   xTaskCreatePinnedToCore(

--- a/PIDKiln_program.ino
+++ b/PIDKiln_program.ino
@@ -447,7 +447,7 @@ void START_Program(){
   Program_start_temp=kiln_temp;
   Energy_Usage=0;
   Program_error=0;
-  TempA_errors=TempB_errors=0;  // Reset temperature errors
+  Temp_Kiln_errors=Temp_Housing_errors=0;  // Reset temperature errors
   
   Enable_EMR();
 
@@ -501,7 +501,7 @@ uint32_t now;
     if (xSemaphoreTake(timerSemaphore, 0) == pdTRUE){
 
       // Update temperature readout
-      Update_TemperatureA();
+      Update_Temperature_Kiln();
 
       // Check if there is Alarm ON - if so, lower time and call STOP
       if(ALARM_countdown>0){
@@ -513,9 +513,9 @@ uint32_t now;
       //
       if(cnt1>9) cnt1=0;
       else cnt1++;
-#ifdef MAXCS2
+#ifdef TC_BOARD_TYPE_HOUSING
       if(cnt1==3){  // just to make it in other time then next if cnt1
-        Update_TemperatureB();      // this does not have to be updated so often as kiln temp
+        Update_Temperature_Housing();      // this does not have to be updated so often as kiln temp
       }
 #endif
 #ifdef ENERGY_MON_PIN


### PR DESCRIPTION
This adds MAX31856 support, the module supports different types of thermocouple.
By defining any TCTYPE (K,J,S,...) in `PIDKiln.h`
```
#define MAXTYPE1 MAX31856_TCTYPE_J
```
adafruit_max31856 lib is imported for reading the temperatures.